### PR TITLE
fix: label encounter XP total as award, not just a total

### DIFF
--- a/src/components/EncounterList.vue
+++ b/src/components/EncounterList.vue
@@ -131,7 +131,13 @@
     <q-card-section class="row items-center q-py-sm">
       <q-badge :color="threatColor" :label="threat" class="q-py-xs q-px-sm text-weight-medium" />
       <q-space />
-      <div class="text-subtitle2">{{ xpCost }} XP</div>
+      <div class="text-subtitle2">
+        {{ xpCost }} XP to award
+        <q-tooltip
+          >Always the 4-character table value — the rules keep XP awards fixed regardless of party size (only
+          the threat budget scales).</q-tooltip
+        >
+      </div>
     </q-card-section>
   </q-card>
 </template>


### PR DESCRIPTION
## Summary
- Encounter list's XP total was just labeled "XP", easily read as scaling with party size. It already didn't — `xpCost` in `encounter-store.ts` never touches `partySize`, only `xpBudget` does. Confirmed against the AoN ruling (https://2e.aonprd.com/Rules.aspx?ID=2715): XP awards always use the 4-character table value; only the threat budget scales with party size.
- Relabeled to "XP to award" with a tooltip explaining why it doesn't change with party size.

closes #43

## Test plan
- [x] Manual check in dev server: badge/tooltip render correctly at party sizes 3/4/6