### PR TITLE
Add issue templates: rules, data, UI perf, feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-rules-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-rules-bug.yml
@@ -1,0 +1,38 @@
+name: "Rules bug"
+description: Encounter/XP math disagrees with GM Core rules-as-written
+labels: ["bug", "rules"]
+body:
+  - type: input
+    id: party
+    attributes:
+      label: Party size and level
+      placeholder: "4 players, level 5"
+    validations:
+      required: true
+  - type: textarea
+    id: creatures
+    attributes:
+      label: Creatures added to the encounter
+      placeholder: "Name, level, and weak/elite adjustment for each"
+    validations:
+      required: true
+  - type: input
+    id: expected
+    attributes:
+      label: Expected XP / budget result
+    validations:
+      required: true
+  - type: input
+    id: actual
+    attributes:
+      label: Actual XP / budget result shown
+    validations:
+      required: true
+  - type: input
+    id: rule-link
+    attributes:
+      label: AoN rules page
+      description: Link to the specific rule this contradicts
+      placeholder: "https://2e.aonprd.com/Rules.aspx?ID=2715"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/02-creature-data.yml
+++ b/.github/ISSUE_TEMPLATE/02-creature-data.yml
@@ -1,0 +1,33 @@
+name: "Creature data bug"
+description: Wrong or stale data in creatures.json / metadata.json
+labels: ["bug", "data"]
+body:
+  - type: input
+    id: creature
+    attributes:
+      label: Creature name
+    validations:
+      required: true
+  - type: input
+    id: expected
+    attributes:
+      label: Expected value (per AoN)
+    validations:
+      required: true
+  - type: input
+    id: actual
+    attributes:
+      label: Actual value shown in app
+    validations:
+      required: true
+  - type: input
+    id: last-updated
+    attributes:
+      label: metadata.json "last updated" date
+      description: Shown in the app footer, or check public/metadata.json
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context

--- a/.github/ISSUE_TEMPLATE/03-ui-perf.yml
+++ b/.github/ISSUE_TEMPLATE/03-ui-perf.yml
@@ -1,0 +1,34 @@
+name: "UI / performance regression"
+description: Table freezes, virtual-scroll broken, or all rows rendering at once
+labels: ["bug", "performance"]
+body:
+  - type: checkboxes
+    id: real-browser
+    attributes:
+      label: Confirmation
+      options:
+        - label: I reproduced this in a real browser (not a headless/automation tool)
+          required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and OS
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+    validations:
+      required: true
+  - type: textarea
+    id: symptom
+    attributes:
+      label: Symptom
+      placeholder: "Freeze, dropped frames, all ~4.7k rows in DOM, scroll jank, etc."
+    validations:
+      required: true
+  - type: textarea
+    id: console
+    attributes:
+      label: Console errors/warnings (if any)

--- a/.github/ISSUE_TEMPLATE/04-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/04-feature-request.yml
@@ -1,0 +1,21 @@
+name: "Feature request"
+description: Suggest new functionality for the encounter builder
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that the app doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered


### PR DESCRIPTION
## Summary
- Adds 4 GitHub issue forms under `.github/ISSUE_TEMPLATE/`: rules bug, creature data bug, UI/perf regression, feature request
- Fields tailored to this repo's known bug history (GM Core math, AoN data staleness, virtual-scroll perf)

## Test plan
- [ ] Open "New issue" on GitHub and confirm all 4 forms render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)