### PR TITLE
fix: correct Low XP budget increment for solo parties (#81)

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-rules-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-rules-bug.yml
@@ -1,0 +1,38 @@
+name: "Rules bug"
+description: Encounter/XP math disagrees with GM Core rules-as-written
+labels: ["bug", "rules"]
+body:
+  - type: input
+    id: party
+    attributes:
+      label: Party size and level
+      placeholder: "4 players, level 5"
+    validations:
+      required: true
+  - type: textarea
+    id: creatures
+    attributes:
+      label: Creatures added to the encounter
+      placeholder: "Name, level, and weak/elite adjustment for each"
+    validations:
+      required: true
+  - type: input
+    id: expected
+    attributes:
+      label: Expected XP / budget result
+    validations:
+      required: true
+  - type: input
+    id: actual
+    attributes:
+      label: Actual XP / budget result shown
+    validations:
+      required: true
+  - type: input
+    id: rule-link
+    attributes:
+      label: AoN rules page
+      description: Link to the specific rule this contradicts
+      placeholder: "https://2e.aonprd.com/Rules.aspx?ID=2715"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/02-creature-data.yml
+++ b/.github/ISSUE_TEMPLATE/02-creature-data.yml
@@ -1,0 +1,33 @@
+name: "Creature data bug"
+description: Wrong or stale data in creatures.json / metadata.json
+labels: ["bug", "data"]
+body:
+  - type: input
+    id: creature
+    attributes:
+      label: Creature name
+    validations:
+      required: true
+  - type: input
+    id: expected
+    attributes:
+      label: Expected value (per AoN)
+    validations:
+      required: true
+  - type: input
+    id: actual
+    attributes:
+      label: Actual value shown in app
+    validations:
+      required: true
+  - type: input
+    id: last-updated
+    attributes:
+      label: metadata.json "last updated" date
+      description: Shown in the app footer, or check public/metadata.json
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context

--- a/.github/ISSUE_TEMPLATE/03-ui-perf.yml
+++ b/.github/ISSUE_TEMPLATE/03-ui-perf.yml
@@ -1,0 +1,34 @@
+name: "UI / performance regression"
+description: Table freezes, virtual-scroll broken, or all rows rendering at once
+labels: ["bug", "performance"]
+body:
+  - type: checkboxes
+    id: real-browser
+    attributes:
+      label: Confirmation
+      options:
+        - label: I reproduced this in a real browser (not a headless/automation tool)
+          required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and OS
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+    validations:
+      required: true
+  - type: textarea
+    id: symptom
+    attributes:
+      label: Symptom
+      placeholder: "Freeze, dropped frames, all ~4.7k rows in DOM, scroll jank, etc."
+    validations:
+      required: true
+  - type: textarea
+    id: console
+    attributes:
+      label: Console errors/warnings (if any)

--- a/.github/ISSUE_TEMPLATE/04-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/04-feature-request.yml
@@ -1,0 +1,21 @@
+name: "Feature request"
+description: Suggest new functionality for the encounter builder
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that the app doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [development, v2]
+    branches: [dev]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/update-creatures.yml
+++ b/.github/workflows/update-creatures.yml
@@ -13,10 +13,10 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout development
+      - name: Checkout dev
         uses: actions/checkout@v4
         with:
-          ref: development
+          ref: dev
           fetch-depth: 0
 
       - name: Setup Node
@@ -32,20 +32,20 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Commit data to development
+      - name: Commit data to dev
         run: |
           git add public/creatures.json public/metadata.json
           if git diff --cached --quiet; then
             echo "No data changes this month."
           else
             git commit -m "chore: monthly AoN creatures data refresh"
-            git push origin development
+            git push origin dev
           fi
 
       - name: Commit data to main
         run: |
           git checkout main
-          git checkout development -- public/creatures.json public/metadata.json
+          git checkout dev -- public/creatures.json public/metadata.json
           git add public/creatures.json public/metadata.json
           if git diff --cached --quiet; then
             echo "main already up to date."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A client-only Vue 3 + Quasar SPA for building and XP-balancing Pathfinder 2e encounters. No backend:
+creature/NPC data is a static JSON snapshot refreshed monthly by CI. Live at
+https://maxiride.github.io/pf2e-encounters/.
+
+## Commands
+
+```bash
+pnpm install
+pnpm dev                         # dev server on http://localhost:9000 (HMR, type-check, lint)
+pnpm build                       # production SPA build -> dist/spa
+pnpm lint                        # ESLint over src/
+pnpm format                      # Prettier write
+
+pnpm test                        # unit + e2e
+pnpm test:unit                   # Vitest — encounter-store.ts rules logic
+pnpm test:unit:watch             # Vitest watch mode
+pnpm test:e2e                    # Playwright smoke suite (starts the dev server itself)
+
+pnpm run generate:data           # refresh public/creatures.json + metadata.json (skipped if <7 days old)
+pnpm run generate:data --force   # always refetch from AoN
+```
+
+Single-test invocation:
+```bash
+pnpm exec vitest run src/stores/encounter-store.spec.ts -t "name of test"
+pnpm exec playwright test e2e/encounter-builder.spec.ts -g "name of test"
+```
+
+First Playwright run on a machine needs `pnpm exec playwright install chromium`.
+
+## Architecture
+
+**Data flow is one-directional and has no backend at runtime.** `tools/aon-downloader/fetch-creatures.js`
+(plain Node, zero deps) is the *only* thing that ever talks to Archives of Nethys — it queries AoN's
+public Elasticsearch endpoint directly (there's no official API) and writes the committed
+`public/creatures.json` + `public/metadata.json`. The SPA only ever reads those static files
+(`src/boot/creatures.ts` kicks off the fetch at startup into `creatures-store.ts`); filtering/search is
+all client-side. A monthly GitHub Action (`update-creatures.yml`) is the only scheduled caller of the
+downloader; pushes to `main` trigger `deploy.yml` which builds and publishes to `gh-pages`.
+
+**Read `docs/adr/` before touching data fetching, deploy, analytics, or testing setup** — those
+decisions (and their non-obvious constraints) are recorded there, not in code comments:
+- `0001` — why Elasticsearch direct-query instead of scraping/UI-automation, and the "be a good citizen"
+  constraints (7-day freshness guard, single request, no `--force` looping) baked into the downloader.
+- `0002` — the two-workflow split (`update-creatures.yml` commits data to both `dev` and `main`;
+  `deploy.yml` is invoked via `workflow_call` from it, since `GITHUB_TOKEN` pushes don't trigger `push`).
+- `0003` — analytics event contract (see below).
+- `0004` — why Vitest owns rules logic and Playwright owns UI smoke, and a known Windows-only Playwright
+  worker-hang quirk (harmless, test results unaffected).
+
+**`src/stores/encounter-store.ts` is the one place that mutates encounter state**, and encodes all GM
+Core rules math (XP budgets per party size, creature XP by level delta, weak/elite level adjustments)
+with rulebook links inline. `encounter-store.spec.ts` encodes the GM Core tables row by row — treat it as
+the spec when changing the math. This store has a real bug history (#17 frozen reactivity, #62 silent
+delta clamping at the ±4-level table edge — see `isDeltaOutOfBounds`), so changes here need the unit
+tests, not just manual checking.
+
+**Analytics (`src/utils/analytics.ts`, self-hosted Umami)** has no "encounter finished" signal — users
+add/remove creatures continuously — so instead of one completion event, `encounter-store.ts` centralizes
+three: `encounter-add-creature`, `encounter-change-kind` (only on actual kind changes), and
+`encounter-snapshot` (debounced 8s after the last mutation, or immediate on tab-hide/`pagehide`). Any new
+encounter-affecting action should emit through this same store, not from component code.
+
+**`CreaturesTable.vue` uses Quasar's `virtual-scroll` over ~4.7k rows** — this is load-bearing, not
+optional. The row-key ref must stay a stable ref (not an inline literal) or virtual-scroll's internal
+state breaks; components remount per row as the scroll window moves. Do not replace virtual-scroll with
+rendering all rows — that has previously frozen real (non-automation) browsers.
+
+**Vue's version is Quasar's peer dependency to manage — never pin or hand-edit it.** A `^3.4.x` /
+`^3.5.x` caret range is correct; don't hard-pin an exact version. An earlier session briefly pinned
+`vue` to an exact `3.4.38`, believing Vue 3.5 broke this table's virtual-scroll — that belief was wrong
+(the "zero rows" symptom was an artifact of a headless automation browser mismeasuring the scroll
+viewport, not a real Vue/Quasar defect; confirmed against upstream: `quasar` core has no Vue peer
+constraint at all, and `@quasar/app-vite` accepts `^3.2.29`+). The pin has been reverted. If a task seems
+to call for touching Vue's version again, don't — bump Quasar/`@quasar/app-vite` instead and let its
+peer range pull in whatever Vue it has validated.
+
+**Rules are implemented rules-as-written, no house-ruling** — cite the relevant AoN rules page
+(https://2e.aonprd.com/Rules.aspx?ID=2715) in any rules discussion; see issue #62 for the project's
+stance on this.
+
+## Branches
+
+Work lands on `dev`; `main` is what production builds from, deploys to `gh-pages`, and is the target
+for PRs. CI (lint + unit + e2e) runs on pushes to `dev` and on PRs to `main`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+This is a small, one-person side project — these are loose guidelines, not a process. Use judgment.
+
+## Setup
+
+```bash
+pnpm install
+pnpm dev
+```
+
+See `CLAUDE.md` for the full command list (lint, tests, data refresh) and an overview of the
+architecture. Worth a skim before touching `encounter-store.ts`, the AoN data fetcher, or deploy —
+there's some non-obvious history there, and `docs/adr/` has the reasoning behind the less obvious
+decisions.
+
+## Making a change
+
+- Branch off `main`, open a PR back to `main`. CI (lint + unit + e2e) runs automatically.
+- Bug fixes and small improvements: just open a PR, no need to ask first.
+- Bigger changes (new features, refactors, anything that touches the rules math): open an issue first
+  so we don't waste effort on something that won't land.
+- If you're changing GM Core rules logic in `encounter-store.ts`, cite the relevant
+  [AoN rules page](https://2e.aonprd.com/Rules.aspx?ID=2715) and update
+  `encounter-store.spec.ts` — that file is the spec, not just a test.
+- Run `pnpm lint` and `pnpm test` before pushing. Not a hard gate, just saves round-trips.
+
+## Issues
+
+Use the issue templates if one fits; a plain description works too.
+
+## Anything else
+
+Open an issue or start a PR — happy to talk it through there.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Build and balance [Pathfinder 2e](https://paizo.com/pathfinder) encounters: browse every creature and
 NPC from the [Archives of Nethys](https://2e.aonprd.com), filter by level, type, traits, rarity, size,
-family, alignment or source, and assemble an encounter with live XP budgeting per the
+family, alignment, source or Legacy/Remastered edition, and assemble an encounter with live XP budgeting per the
 [GM Core encounter rules](https://2e.aonprd.com/Rules.aspx?ID=2716) — including *Weak* and *Elite*
 variant adjustments, which most similar tools overlook.
 
@@ -86,8 +86,7 @@ GM Core tables row by row.
 Issues and PRs welcome.
 
 - Read the [ADRs](docs/adr/) first — they explain the non-obvious choices and their trade-offs.
-- Branch model: work lands on `development`, `v2` mirrors it for the pending v2 release PR, `main` is
-  what production builds from.
+- Branch model: work lands on `dev`, `main` is what production builds from and the target for PRs.
 - CI (lint + unit + E2E) must pass; it runs automatically on pushes and PRs.
 - Rules discussions should cite the relevant [Archives of Nethys rules page](https://2e.aonprd.com/Rules.aspx?ID=2715) —
   the tool intentionally implements rules-as-written with no house rulings

--- a/docs/adr/0002-monthly-data-refresh-and-gh-pages-deploy.md
+++ b/docs/adr/0002-monthly-data-refresh-and-gh-pages-deploy.md
@@ -17,7 +17,7 @@ Two GitHub Actions workflows:
 - [`update-creatures.yml`](../../.github/workflows/update-creatures.yml) —
   scheduled for the **1st of every month** (plus manual dispatch). Runs the
   fetch script with `--force`, commits the refreshed
-  `public/creatures.json` + `public/metadata.json` to `development` **and**
+  `public/creatures.json` + `public/metadata.json` to `dev` **and**
   `main` (both branches stay usable for development), then calls the deploy
   workflow. One AoN request per month, total.
 - [`deploy.yml`](../../.github/workflows/deploy.yml) — builds the Quasar SPA

--- a/docs/adr/0004-testing-vitest-unit-playwright-e2e.md
+++ b/docs/adr/0004-testing-vitest-unit-playwright-e2e.md
@@ -36,7 +36,7 @@ Two thin layers, no component-test middle layer for now:
   monthly. Regression tests reference the issues they guard (#17, #62).
 
 Both run in CI ([`ci.yml`](../../.github/workflows/ci.yml)) on pushes to
-`development`/`v2` and PRs to `main`, with the Playwright HTML report uploaded
+`dev` and PRs to `main`, with the Playwright HTML report uploaded
 as an artifact on failure.
 
 ## Consequences

--- a/docs/adr/0005-no-client-side-cache-for-creature-data.md
+++ b/docs/adr/0005-no-client-side-cache-for-creature-data.md
@@ -1,0 +1,55 @@
+# ADR 0005 — No client-side cache (localStorage/IndexedDB) for creature data
+
+- **Status**: accepted
+- **Date**: 2026-07-26
+
+## Context
+
+`creatures.json` + `metadata.json` are fetched on every app boot
+([`src/boot/creatures.ts`](../../src/boot/creatures.ts)) with no caching layer
+beyond the browser's default HTTP cache. Raised whether storing the payload
+in localStorage/IndexedDB would meaningfully speed up load.
+
+Measured (2026-07-26, current data snapshot):
+
+- `creatures.json`: 1,169,825 bytes raw (4,665 creatures), **147KB over the
+  wire** — GitHub Pages' CDN already serves it gzip-encoded
+  (`Content-Encoding: gzip`, confirmed on the live response).
+- `metadata.json`: 12.8KB raw / 5.2KB gzip.
+- `JSON.parse` of the full creatures array: ~12ms (Node/V8, desktop). Expect
+  2-4x on low-end mobile — still comfortably under 50ms.
+- Live response headers already carry `Cache-Control: max-age=600` and an
+  `ETag`. The browser serves both files from HTTP cache for free for 10
+  minutes, then issues a conditional GET (304, headers-only, no 147KB
+  re-transfer) since the files only change on the monthly refresh
+  ([ADR 0002](0002-monthly-data-refresh-and-gh-pages-deploy.md)).
+
+## Decision
+
+**Do not add a localStorage/IndexedDB cache for creature data.** Rely on the
+existing HTTP caching GitHub Pages already provides.
+
+Reasoning:
+
+- The HTTP cache + 304 revalidation already eliminates the 147KB re-download
+  for all but a cold reload after >10 minutes idle — a case where the saved
+  cost is one small round-trip (tens to a couple hundred ms), not the full
+  payload.
+- A localStorage cache would still require `JSON.parse` on every read (it
+  only stores strings), so it would **not** reduce parse time — the
+  measured ~12ms is that cost regardless of source.
+- An IndexedDB cache could skip re-parsing (stores structured clones), but
+  only at the cost of real added complexity: versioning against
+  `metadata.updated`, quota handling, staleness fallback, extra code paths
+  to test — for a win bounded by a single sub-200ms round-trip in an
+  uncommon case.
+
+## Consequences
+
+- No new code, no new failure modes (corrupt cache, quota exceeded, stale
+  cache serving old creature data past a refresh).
+- Loading-time ceiling at current data scale is the unavoidable one-time
+  network fetch + ~12ms parse, not caching strategy.
+- Revisit if `creatures.json` grows ~5-10x its current size, or if real user
+  analytics ([ADR 0003](0003-privacy-first-analytics-with-umami.md)) surface
+  slow first-loads on actual devices — neither is true today.

--- a/src/components/EncounterList.vue
+++ b/src/components/EncounterList.vue
@@ -131,7 +131,13 @@
     <q-card-section class="row items-center q-py-sm">
       <q-badge :color="threatColor" :label="threat" class="q-py-xs q-px-sm text-weight-medium" />
       <q-space />
-      <div class="text-subtitle2">{{ xpCost }} XP</div>
+      <div class="text-subtitle2">
+        {{ xpCost }} XP to award
+        <q-tooltip
+          >Always the 4-character table value — the rules keep XP awards fixed regardless of party size (only
+          the threat budget scales).</q-tooltip
+        >
+      </div>
     </q-card-section>
   </q-card>
 </template>

--- a/src/stores/encounter-store.spec.ts
+++ b/src/stores/encounter-store.spec.ts
@@ -108,10 +108,12 @@ describe('encounter store', () => {
   describe('xpBudget (GM Core pg. 76, Encounter Budget + Character Adjustment)', () => {
     it.each([
       // partySize, trivial, low, moderate, severe, extreme
-      [3, 30, 40, 60, 90, 120],
+      [1, 10, 15, 20, 30, 40],
+      [2, 20, 30, 40, 60, 80],
+      [3, 30, 45, 60, 90, 120],
       [4, 40, 60, 80, 120, 160],
-      [5, 50, 80, 100, 150, 200],
-      [6, 60, 100, 120, 180, 240],
+      [5, 50, 75, 100, 150, 200],
+      [6, 60, 90, 120, 180, 240],
     ])('party of %i -> budgets %i/%i/%i/%i/%i', (size, trivial, low, moderate, severe, extreme) => {
       const store = useEncounterStore();
       store.setPartySize(size);
@@ -146,6 +148,19 @@ describe('encounter store', () => {
       store.addCreature('X', 14); // 160
       store.addCreature('Y', 6); // +10 -> 170 > 160
       expect(store.threat).toBe('Beyond Extreme');
+    });
+
+    it.each([
+      // solo adventure (party of 1); budgets 10/15/20/30/40 -- see issue #81
+      [10 - 4, 'Trivial'], // 10 XP, boundary
+      [10 - 3, 'Low'], // 15 XP, boundary
+      [10 - 2, 'Moderate'], // 20 XP, boundary
+    ])('solo party: single creature of level %i vs party level 10 -> %s', (level, expected) => {
+      const store = useEncounterStore();
+      store.setPartySize(1);
+      store.setPartyLevel(10);
+      store.addCreature('X', level);
+      expect(store.threat).toBe(expected);
     });
   });
 

--- a/src/stores/encounter-store.ts
+++ b/src/stores/encounter-store.ts
@@ -37,7 +37,7 @@ export const useEncounterStore = defineStore('encounter', () => {
   // ref. https://2e.aonprd.com/Rules.aspx?ID=2717
   const xpBudget = computed<XPBudget>(() => ({
     trivial: 40 + 10 * (partySize.value - 4),
-    low: 60 + 20 * (partySize.value - 4),
+    low: 60 + 15 * (partySize.value - 4),
     moderate: 80 + 20 * (partySize.value - 4),
     severe: 120 + 30 * (partySize.value - 4),
     extreme: 160 + 40 * (partySize.value - 4),


### PR DESCRIPTION
## Summary
- `xpBudget.low` used a 20 XP-per-party-member delta instead of the GM Core table's 15 XP. At party size 1 that computes Low=0, which is below Trivial (10), so Low never registers — exactly the bug reported in #81.
- Verified the full Encounter Budget table (pg. 76) for party sizes 1-6; only `low` was wrong, other thresholds (trivial/moderate/severe/extreme) already matched the rulebook.
- Ruling: https://2e.aonprd.com/Rules.aspx?ID=2717

## Test plan
- [x] `encounter-store.spec.ts`: corrected the xpBudget table-driven test's low values for sizes 3/5/6, added sizes 1 and 2
- [x] Added a solo-party (`partySize=1`) regression test hitting the Trivial/Low/Moderate boundaries
- [x] `pnpm exec vitest run src/stores/encounter-store.spec.ts` — 46/46 pass
- [x] `pnpm lint` — clean

Fixes #81