### PR TITLE
fix: grant pages/id-token permissions to deploy job call

### DIFF
--- a/.github/workflows/update-creatures.yml
+++ b/.github/workflows/update-creatures.yml
@@ -60,4 +60,6 @@ jobs:
     needs: update
     uses: ./.github/workflows/deploy.yml
     permissions:
-      contents: write
+      contents: read
+      pages: write
+      id-token: write


### PR DESCRIPTION
## Summary
- `update-creatures.yml`'s `deploy:` job calls `deploy.yml` via `workflow_call` but only granted `contents: write`, while `deploy.yml` requires `pages: write` and `id-token: write`.
- Reusable-workflow permissions are an explicit allowlist — anything not granted by the caller job is `none`, regardless of what the callee's own `permissions:` block asks for.
- GitHub validates this before scheduling any job, so the monthly scheduled run failed with `startup_failure` and 0 jobs created (run [30688257316](https://github.com/maxiride/pf2e-encounters/actions/runs/30688257316)). Exact error: `"The workflow is requesting 'pages: write, id-token: write', but is only allowed 'pages: none, id-token: none'."`

## Fix
Grant the `deploy:` job exactly what `deploy.yml` requests: `contents: read`, `pages: write`, `id-token: write`. The `update` job is unaffected — it still runs under the workflow's top-level `contents: write`.

## Test plan
- [ ] Manually trigger `Monthly creatures data update` via `workflow_dispatch` after merge and confirm the `deploy` job now starts and completes.

Claude-Session: https://claude.ai/code/session_0145tfdgDzuGik1kSHCXPQCv