### PR TITLE
fix: run update-creatures.yml tooling from main, not dev

### DIFF
--- a/.github/workflows/update-creatures.yml
+++ b/.github/workflows/update-creatures.yml
@@ -14,10 +14,20 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+      # Tooling (fetch-creatures.js, validate-creatures.js, this workflow) lives
+      # on main. dev is a data-only checkout, used just as a commit target below —
+      # never run scripts against a dev checkout, it can lag main's tooling.
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
       - name: Checkout dev
         uses: actions/checkout@v4
         with:
           ref: dev
+          path: dev-checkout
           fetch-depth: 0
 
       - name: Setup Node
@@ -27,7 +37,7 @@ jobs:
 
       - name: Read previous creature count
         id: previous_count
-        run: echo "count=$(node -e "console.log(require('./public/creatures.json').length)")" >> "$GITHUB_OUTPUT"
+        run: echo "count=$(node -e "console.log(require('./dev-checkout/public/creatures.json').length)")" >> "$GITHUB_OUTPUT"
 
       - name: Fetch creatures from AoN
         run: node tools/aon-downloader/fetch-creatures.js --force
@@ -39,9 +49,13 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C dev-checkout config user.name "github-actions[bot]"
+          git -C dev-checkout config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Commit data to dev
         run: |
+          cp public/creatures.json public/metadata.json dev-checkout/public/
+          cd dev-checkout
           git add public/creatures.json public/metadata.json
           if git diff --cached --quiet; then
             echo "No data changes this month."
@@ -55,9 +69,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           BRANCH="data-refresh/$(date +%Y-%m-%d)"
-          git fetch origin main
-          git checkout -b "$BRANCH" origin/main
-          git checkout dev -- public/creatures.json public/metadata.json
+          git checkout -b "$BRANCH"
           git add public/creatures.json public/metadata.json
           if git diff --cached --quiet; then
             echo "main already up to date."


### PR DESCRIPTION
## Summary
After #85 merged, the next run ([30757907862](https://github.com/maxiride/pf2e-encounters/actions/runs/30757907862)) failed at the new `Validate creature data` step:
```
Error: Cannot find module '/home/runner/work/pf2e-encounters/pf2e-encounters/tools/aon-downloader/validate-creatures.js'
```

The `update` job's first step was `Checkout dev`, which replaces the *entire* working tree with `dev`'s content before any other step runs. `dev` and `main` have drifted 13 files apart — `dev` never received `validate-creatures.js`, `ci.yml`, `update-creatures.yml` itself, or several other main-only merges — because nothing in this repo's process pushes `main` changes back onto `dev`; only the automated data commit flows the other way.

## Fix
- Checkout `main` at the default path (where the tooling actually lives) and run `fetch-creatures.js` / `validate-creatures.js` there.
- Checkout `dev` separately into `dev-checkout/`, used purely as a commit target: the freshly generated `public/creatures.json` + `metadata.json` are copied in and committed there.
- `Open PR to main` no longer needs a second checkout of `main` — the job is already on `main` from the first step.

## Test plan
- [x] `git diff origin/main -- .github/workflows/update-creatures.yml` reviewed — isolated to the checkout/copy restructuring, no unrelated changes
- [x] YAML parsed with `js-yaml` locally, structure confirmed
- [ ] Manually trigger `Monthly creatures data update` via `workflow_dispatch` after merge and confirm `Validate creature data` and the rest of the job succeed