### PR TITLE
feat: summarize creature/metadata diff in the monthly refresh PR body

### DIFF
--- a/.github/workflows/update-creatures.yml
+++ b/.github/workflows/update-creatures.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Validate creature data
         run: node tools/aon-downloader/validate-creatures.js --previous-count=${{ steps.previous_count.outputs.count }}
 
+      - name: Generate data diff summary
+        run: node tools/aon-downloader/summarize-diff.js dev-checkout/public/creatures.json dev-checkout/public/metadata.json > data-diff-summary.md
+
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
@@ -76,7 +79,12 @@ jobs:
           else
             git commit -m "chore: monthly AoN creatures data refresh"
             git push origin "$BRANCH"
+            {
+              echo "Automated monthly AoN data refresh. Validated by \`validate:data\` in CI before merge."
+              echo
+              cat data-diff-summary.md
+            } > pr-body.md
             gh pr create --base main --head "$BRANCH" \
               --title "chore: monthly AoN creatures data refresh" \
-              --body "Automated monthly AoN data refresh. Validated by \`validate:data\` in CI before merge."
+              --body-file pr-body.md
           fi

--- a/tools/aon-downloader/summarize-diff.js
+++ b/tools/aon-downloader/summarize-diff.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/*
+  Summarizes what changed between a previous and a freshly fetched
+  creatures.json + metadata.json, as Markdown (used as the monthly
+  data-refresh PR body).
+
+  Creatures are matched by `url` (AoN's page path), the only field
+  guaranteed unique - `name` has hundreds of duplicates in the corpus
+  (reprints, generic NPC names).
+
+  Usage:
+    node summarize-diff.js <old-creatures.json> <old-metadata.json> [new-creatures.json] [new-metadata.json]
+
+  new-creatures.json/new-metadata.json default to ./public/creatures.json
+  and ./public/metadata.json.
+*/
+
+import fs from 'node:fs';
+
+const MAX_LISTED = 30;
+
+const [, , oldCreaturesPath, oldMetadataPath, newCreaturesPath = 'public/creatures.json', newMetadataPath = 'public/metadata.json'] =
+  process.argv;
+
+if (!oldCreaturesPath || !oldMetadataPath) {
+  console.error('Usage: summarize-diff.js <old-creatures.json> <old-metadata.json> [new-creatures.json] [new-metadata.json]');
+  process.exit(1);
+}
+
+const readJson = (p) => JSON.parse(fs.readFileSync(p, 'utf8'));
+
+const oldCreatures = readJson(oldCreaturesPath);
+const newCreatures = readJson(newCreaturesPath);
+const oldMetadata = readJson(oldMetadataPath);
+const newMetadata = readJson(newMetadataPath);
+
+const byUrl = (list) => new Map(list.map((c) => [c.url, c]));
+const oldByUrl = byUrl(oldCreatures);
+const newByUrl = byUrl(newCreatures);
+
+const added = [...newByUrl.keys()].filter((url) => !oldByUrl.has(url)).map((url) => newByUrl.get(url));
+const removed = [...oldByUrl.keys()].filter((url) => !newByUrl.has(url)).map((url) => oldByUrl.get(url));
+
+const CREATURE_FIELDS = ['name', 'level', 'hp', 'ac', 'rarity', 'size', 'traits', 'family', 'sources', 'npc', 'alignment', 'edition'];
+const changed = [];
+for (const [url, oldC] of oldByUrl) {
+  const newC = newByUrl.get(url);
+  if (!newC) continue;
+  const diffFields = CREATURE_FIELDS.filter((f) => JSON.stringify(oldC[f]) !== JSON.stringify(newC[f]));
+  if (diffFields.length) changed.push({ name: newC.name, url, fields: diffFields });
+}
+
+function listSection(title, items, toLine) {
+  if (!items.length) return `- ${title}: 0\n`;
+  const lines = items.slice(0, MAX_LISTED).map(toLine);
+  const more = items.length > MAX_LISTED ? `\n- …and ${items.length - MAX_LISTED} more` : '';
+  return (
+    `- ${title}: ${items.length}\n` +
+    `<details><summary>${title} (${items.length})</summary>\n\n` +
+    lines.map((l) => `  - ${l}`).join('\n') +
+    more +
+    '\n\n</details>\n'
+  );
+}
+
+function arrayFieldDiff(label, oldArr, newArr) {
+  const oldSet = new Set(oldArr);
+  const newSet = new Set(newArr);
+  const added = [...newSet].filter((x) => !oldSet.has(x));
+  const removed = [...oldSet].filter((x) => !newSet.has(x));
+  if (!added.length && !removed.length) return `- ${label}: unchanged (${newArr.length})\n`;
+  const parts = [];
+  if (added.length) parts.push(`+${added.length} (${added.join(', ')})`);
+  if (removed.length) parts.push(`-${removed.length} (${removed.join(', ')})`);
+  return `- ${label}: ${parts.join(', ')}\n`;
+}
+
+const lines = [];
+lines.push('## Creature data changes\n');
+lines.push(`- Total: ${newCreatures.length} (was ${oldCreatures.length}, ${newCreatures.length - oldCreatures.length >= 0 ? '+' : ''}${newCreatures.length - oldCreatures.length})\n`);
+lines.push(listSection('Added', added, (c) => `${c.name} (level ${c.level})`));
+lines.push(listSection('Removed', removed, (c) => `${c.name} (level ${c.level})`));
+lines.push(listSection('Changed', changed, (c) => `${c.name}: ${c.fields.join(', ')}`));
+
+lines.push('## Metadata changes\n');
+lines.push(arrayFieldDiff('Traits', oldMetadata.traits, newMetadata.traits));
+lines.push(arrayFieldDiff('Rarities', oldMetadata.rarities, newMetadata.rarities));
+lines.push(arrayFieldDiff('Sizes', oldMetadata.sizes, newMetadata.sizes));
+lines.push(arrayFieldDiff('Sources', oldMetadata.sources, newMetadata.sources));
+lines.push(arrayFieldDiff('Families', oldMetadata.families, newMetadata.families));
+lines.push(arrayFieldDiff('Alignments', oldMetadata.alignments, newMetadata.alignments));
+if (oldMetadata.levels.min !== newMetadata.levels.min || oldMetadata.levels.max !== newMetadata.levels.max) {
+  lines.push(
+    `- Level range: ${oldMetadata.levels.min}..${oldMetadata.levels.max} → ${newMetadata.levels.min}..${newMetadata.levels.max}\n`,
+  );
+} else {
+  lines.push(`- Level range: unchanged (${newMetadata.levels.min}..${newMetadata.levels.max})\n`);
+}
+
+process.stdout.write(lines.join(''));


### PR DESCRIPTION
## Summary
The monthly data-refresh PR (opened by `update-creatures.yml`) had no summary of what actually changed. Adds a diff summary as the PR body: creatures added/removed/changed, and metadata field changes (traits/rarities/sizes/sources/families/alignments/level range).

## Changes
- **`tools/aon-downloader/summarize-diff.js`** (new): compares old vs. new `creatures.json`/`metadata.json`. Creatures are matched by `url` — `name` has 810 duplicates in the current corpus (reprints, generic NPC names), `url` (AoN's page path) is the only field that's actually unique. Reports counts plus a capped (30-item) detail list per section; per-metadata-array-field added/removed values; level range before/after.
- **`update-creatures.yml`**: new `Generate data diff summary` step runs right after validation, before `dev-checkout`'s old files get overwritten by the commit step. `Open PR to main` now builds the PR body from a static intro line + this summary via `--body-file`.

## Test plan
- [x] Ran `summarize-diff.js` against the real committed data with a synthetic "previous run" (2 creatures removed, 1 hp change, 1 metadata trait removed) — output correctly reported Added: 2, Changed: 1 (hp), metadata Traits: +1
- [x] YAML re-parsed with `js-yaml`, step order confirmed: fetch → validate → diff summary → commit to dev (which is when dev-checkout's old files get overwritten)
- [ ] Manually trigger `Monthly creatures data update` via `workflow_dispatch` after merge and confirm the opened PR body shows a real diff summary